### PR TITLE
Fix downloading functionality, add DNS note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,51 @@
 # [Anna's Archive Calibre Store](https://github.com/ScottBot10/calibre_annas_archive)
 
 A [Calibre](https://calibre-ebook.com/) store plugin for [Anna's Archive](https://annas-archive.org/).
+
 > 📚 The largest truly open library in human history.
 > ⭐️ We mirror Sci-Hub and LibGen. We scrape and open-source Z-Lib, DuXiu, and more.
 
 ## Installation
+
 ### From Releases
+
 To add this plugin, go to the latest [release](https://github.com/ScottBot10/calibre_annas_archive/releases)
 and download the file that looks like `calibre_annas_archive-vx.x.x.zip` where the x's are the version number, 
 then in Calibre go to `Preferences > Plugins`, click `Load plugin from file` and select your downloaded zip file.
 
 ### From source
+
 You could also install it from the source by cloning this repository and running:
+
 ```shell
 calibre-customize -b <path to cloned repo>
 ```
+
 or if you're on Linux, you can run the shell script to create the zip file and then add that:
+
 ```shell
 ./zip_release.sh && calibre-customize -a $(ls calibre_annas_archive-v*.zip -1rt | tail -n1)
 ```
+
 ## Configuration
+
 You can change configuration by going to 
 `Preferences > Plugins > Store` and scrolling down to and double-clicking `Anna's Archive (x.x.x) by ScottBot10`
 to open the settings menu.
 
 ### Search Options
+
 This plugin has the same search options as the actual site.
 For each checkbox option e.g. filetype, language: if no boxes are checked, then it doesn't filter on that option.
 But if any are checked then it will only show results that match that selection.
 
-### Download link options
-These options affect what files are shown in the downloads found by the search (the green arrow button).
-- **Verify Content-Type:** Make a HEAD request to each site and check if it has an 'application' Content-Type
-- **Verify url extension:** Check whether the url ends with the extension of the file's format
-
 ### Mirrors
+
 This is a list of mirrors that the plugin will try, in the specified order, to access.
 You can change the order of, delete, and add mirror urls.
+
+## Issues with queries
+
+Your DNS provider may block queries to all 3 mirrors, causing errors in Calibre such as an instant 'no books found'. 
+
+In this case, you should set your DNS to a public DNS server, eg. Cloudflare's `1.1.1.1` and `1.0.0.1`.

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ class AnnasArchiveStore(StoreBase):
     description         = 'The world\'s largest open-source open-data library.'
     supported_platforms = ['windows', 'osx', 'linux']
     author              = 'ScottBot10'
-    version             = (0, 2, 4)
+    version             = (0, 2, 5)
     minimum_calibre_version = (5, 0, 0)
     formats             = ['EPUB', 'MOBI', 'PDF', 'AZW3', 'CBR', 'CBZ', 'FB2']
     drm_free_only       = True

--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ class ConfigWidget(QWidget):
         main_layout.addWidget(search_options)
 
         horizontal_layout = QHBoxLayout()
-
+        """
         link_options = QGroupBox(_('Download link options'), self)
         link_options.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         link_layout = QVBoxLayout(link_options)
@@ -113,6 +113,8 @@ class ConfigWidget(QWidget):
             'Get the header of each site and verify that it has an \'application\' content type'))
         link_layout.addWidget(self.content_type)
         horizontal_layout.addWidget(link_options)
+        """
+        
 
         mirrors = QGroupBox(_('Mirrors'), self)
         layout = QVBoxLayout(mirrors)
@@ -122,10 +124,10 @@ class ConfigWidget(QWidget):
         horizontal_layout.addWidget(mirrors)
 
         main_layout.addLayout(horizontal_layout)
-
-        self.open_external = QCheckBox(_('Open store in external web browser'), self)
+        
+        self.open_external = QCheckBox(_('Open store in external web browser (internal web browser may not work)'), self)
         main_layout.addWidget(self.open_external)
-
+        
         self.load_settings()
 
     def _make_cbx_group(self, parent, option: SearchConfiguration, scrollbar: bool = False):
@@ -165,8 +167,8 @@ class ConfigWidget(QWidget):
 
     def load_settings(self):
         config = self.store.config
-
-        self.open_external.setChecked(config.get('open_external', False))
+        # Default it to ticked because of the internal browser bug
+        self.open_external.setChecked(config.get('open_external', True))
         self.mirrors.load_mirrors(config.get('mirrors', DEFAULT_MIRRORS))
 
         search_opts = config.get('search', {})
@@ -174,8 +176,8 @@ class ConfigWidget(QWidget):
             configuration.load(search_opts.get(configuration.config_option, configuration.default))
 
         link_opts = config.get('link', {})
-        self.url_extension.setChecked(link_opts.get('url_extension', True))
-        self.content_type.setChecked(link_opts.get('content_type', False))
+        #self.url_extension.setChecked(link_opts.get('url_extension', True))
+        #self.content_type.setChecked(link_opts.get('content_type', False))
 
     def save_settings(self):
         self.store.config['open_external'] = self.open_external.isChecked()
@@ -185,7 +187,9 @@ class ConfigWidget(QWidget):
             configuration.config_option: configuration.to_save()
             for configuration in self.search_options.values()
         }
+        """
         self.store.config['link'] = {
             'url_extension': self.url_extension.isChecked(),
             'content_type': self.content_type.isChecked()
         }
+        """

--- a/constants.py
+++ b/constants.py
@@ -9,7 +9,7 @@ __all__ = (
     'FileType', 'Source', 'Language'
 )
 
-DEFAULT_MIRRORS = ['https://annas-archive.org', 'https://annas-archive.li', 'https://annas-archive.se']
+DEFAULT_MIRRORS = ['https://annas-archive.org', 'https://annas-archive.se', 'https://annas-archive.li']
 RESULTS_PER_PAGE = 100
 
 


### PR DESCRIPTION
### Fixes

Fixes issue #9.

### Description

1. Z-Lib and LibGen have updated their UIs so code has been updated to keep these on track.
2. Remove libgen.li downloading due to Cloudflare 'Phishing Warnings'.
3. On Debian (RPi armhf), calling `WebStoreDialog` returns an error. Not tested on other platforms. Add a try except clause to catch this error and open it in an external browser instead.
4. Remove url extension checking in favour of MIME checking because many links don't actually have an extension.
5. Update plugin config accordingly.
6. Add a note in the README about DNS.

